### PR TITLE
Add support for precomputed route segments

### DIFF
--- a/src/mapas.js
+++ b/src/mapas.js
@@ -98,7 +98,7 @@ export function mostrarPuntoDePartida(lat, lon) {
   map.setView([lat, lon], 13);
 }
 
-export async function mostrarRutaOptima(ruta) {
+export async function mostrarRutaOptima(ruta,segmentos=null) {
   if (rutaLayer) {
     map.removeLayer(rutaLayer);
   }
@@ -107,7 +107,9 @@ export async function mostrarRutaOptima(ruta) {
 
   for (let i = 0; i < ruta.length - 1; i++) {
     try {
-      const segmento = await trazarRutaORS(ruta[i], ruta[i + 1]);
+      const segmento = segmentos && segmentos[i]
+        ? segmentos[i]
+        : await trazarRutaORS(ruta[i], ruta[i + 1]);
 
       if (!segmento || segmento.length === 0) {
         throw new Error("Ruta vacía");

--- a/src/ruta.js
+++ b/src/ruta.js
@@ -105,6 +105,8 @@ if (listaDestinos) {
   let noVisitados = [...destinos];
   let actual = puntoPartida;
   const destinosOmitidos = [];
+  const segmentos = [];
+
 
   while (noVisitados.length > 0) {
     try {
@@ -122,7 +124,8 @@ if (listaDestinos) {
       });
 
       if (destinoMasCercano) {
-        await trazarRutaORS(actual, destinoMasCercano, false);
+        const segmento = await trazarRutaORS(actual, destinoMasCercano, false);
+        segmentos.push(segmento);
         ruta.push(destinoMasCercano);
         actual = destinoMasCercano;
         noVisitados.splice(indiceCercano, 1);


### PR DESCRIPTION
Se actualizó mostrarRutaOptima para que acepte el parámetro opcional "segmentos", lo que permite usar segmentos de ruta precalculados en lugar de llamar siempre a trazarRutaORS. Se modificó ruta.js para recopilar y pasar estos segmentos, lo que mejora la flexibilidad y la eficiencia cuando los segmentos de ruta ya están disponibles.